### PR TITLE
Add Input: `version` (and Rename Others)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# wipac-dev-rest-interface-schema-action
-GitHub Action Package for Standardizing and Organizing a REST Interface's Schema
+# wipac-dev-json-schema-action
+
+GitHub Action Package for Standardizing and Organizing a Project's JSON Schema / OpenAPI Files

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'The location to output the compiled openapi spec JSON file'
     required: true
   version:
-    description: 'The version number to prepend to each route and update in the openapi schema (future: automate version finding)'
+    description: 'The semantic version for whose major component is prepended to each route; also updates the openapi schema (future: automate version finding)'
     required: true
   # OPTIONAL
   db_jsonschema_dir:
@@ -83,11 +83,18 @@ runs:
         git config user.email ${{ inputs.git_committer_email }}
       shell: bash
 
-    - name: modify REST path schemas - ${{ inputs.rest_openapi_paths_dir }}
+    - name: incorporate semantic version (${{ inputs.version }})
       if: env.IS_GIT_BEHIND != 'true'
       run: |
         set -euo pipefail
         echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
+        
+        if [[ "${{ inputs.version }}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+          echo "valid semver"
+        else
+          echo "::error::Invalid semver: ${{ inputs.version }}"
+          exit 2
+        fi
         
         TMP_FILE="$(mktemp)"
         jq --arg version "${{ inputs.version }}" \

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: 'wipac-dev-rest-interface-schema-action'
-description: "GitHub Action Package for Standardizing and Organizing a REST Interface's Schema"
+name: 'wipac-dev-json-schema-action'
+description: "GitHub Action Package for Standardizing and Organizing a Project's JSON Schema / OpenAPI Files"
 
 inputs:
   rest_openapi_paths_dir:
@@ -34,6 +34,8 @@ runs:
   steps:
     - name: check required inputs
       run: |
+        set -euo pipefail
+        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         if [ -z "${{ inputs.rest_openapi_paths_dir }}" ]; then
           echo "ERROR: required input not provided: rest_openapi_paths_dir"
           exit 1
@@ -54,6 +56,8 @@ runs:
 
     - name: Is this the most recent commit? It won't be if the action was reran
       run: |
+        set -euo pipefail
+        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         git fetch
         if [[ $(git status -sb | grep behind) ]]; then
           echo "this commit is not the most recent on this branch -- rest of action will be skipped"
@@ -66,6 +70,8 @@ runs:
     - name: Git config
       if: env.IS_GIT_BEHIND != 'true'
       run: |
+        set -euo pipefail
+        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         git config user.name ${{ inputs.git_committer_name }}
         git config user.email ${{ inputs.git_committer_email }}
       shell: bash
@@ -73,6 +79,8 @@ runs:
     - name: modify REST path schemas - ${{ inputs.rest_openapi_paths_dir }}
       if: env.IS_GIT_BEHIND != 'true'
       run: |
+        set -euo pipefail
+        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         python ${{ github.action_path }}/scripts/modify_rest_path_schemas.py \
             ${{ github.workspace }}/${{ inputs.rest_openapi_paths_dir }}
       shell: bash
@@ -80,6 +88,8 @@ runs:
     - name: modify DB schemas - ${{ inputs.db_jsonschema_dir }}
       if: env.IS_GIT_BEHIND != 'true' && inputs.db_jsonschema_dir != ''
       run: |
+        set -euo pipefail
+        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         python ${{ github.action_path }}/scripts/modify_db_schemas.py \
             ${{ github.workspace }}/${{ inputs.db_jsonschema_dir }}
       shell: bash
@@ -87,6 +97,8 @@ runs:
     - name: auto-build ${{ inputs.rest_openapi_spec_fpath }}
       if: env.IS_GIT_BEHIND != 'true'
       run: |
+        set -euo pipefail
+        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         # NOTE: DO NOT CHANGE THE CONTENTS OF THE SCHEMA, ONLY ASSEMBLE.
         #
         # ANY MODIFICATIONS SHOULD BE MADE TO **ORIGINAL FILES**
@@ -101,6 +113,8 @@ runs:
     - name: Push changes
       if: env.IS_GIT_BEHIND != 'true'
       run: |
+        set -euo pipefail
+        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         git add . || true
         git commit -m "<ci> modify openapi/jsonschema file(s)" || true
         git push || true

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'The location to output the compiled openapi spec JSON file'
     required: true
   version:
-    description: 'The version number to append to each route and update in the the openapi schema (future: automate version finding)'
+    description: 'The version number to prepend to each route and update in the openapi schema (future: automate version finding)'
     required: true
   # OPTIONAL
   db_jsonschema_dir:
@@ -40,15 +40,19 @@ runs:
         set -euo pipefail
         echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         if [ -z "${{ inputs.rest_openapi_paths_dir }}" ]; then
-          echo "ERROR: required input not provided: rest_openapi_paths_dir"
+          echo "::error::required input not provided: rest_openapi_paths_dir"
           exit 1
         fi
         if [ -z "${{ inputs.rest_openapi_prebuild_fpath }}" ]; then
-          echo "ERROR: required input not provided: rest_openapi_prebuild_fpath"
+          echo "::error::required input not provided: rest_openapi_prebuild_fpath"
           exit 1
         fi
         if [ -z "${{ inputs.rest_openapi_spec_fpath }}" ]; then
-          echo "ERROR: required input not provided: rest_openapi_spec_fpath"
+          echo "::error::required input not provided: rest_openapi_spec_fpath"
+          exit 1
+        fi
+        if [ -z "${{ inputs.version }}" ]; then
+          echo "::error::required input not provided: version"
           exit 1
         fi
       shell: bash
@@ -80,7 +84,7 @@ runs:
       shell: bash
 
     - name: modify REST path schemas - ${{ inputs.rest_openapi_paths_dir }}
-      if: env.IS_GIT_BEHIND != 'true' && inputs.version != ''
+      if: env.IS_GIT_BEHIND != 'true'
       run: |
         set -euo pipefail
         echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"

--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ runs:
         
         # edit
         TMP_FILE="$(mktemp)"
-        jq --arg version "${{ inputs.version }}" \
+        jq --indent 4 --arg version "${{ inputs.version }}" \
             '.info.version = $version' "${{ inputs.rest_openapi_base_fpath }}" \
             > "$TMP_FILE"
         mv "$TMP_FILE" "${{ inputs.rest_openapi_base_fpath }}"

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,10 @@ inputs:
   rest_openapi_paths_dir:
     description: 'The directory containing openapi-valid JSON files, one for each REST endpoint (path)'
     required: true
-  rest_openapi_prebuild_fpath:
-    description: 'The pre-compiled JSON file with special macros/tokens to compile into an openapi spec (rest_openapi_spec_fpath)'
+  rest_openapi_base_fpath:
+    description: 'The pre-compiled JSON file with special macros/tokens to compile into an openapi spec (rest_openapi_dest_fpath)'
     required: true
-  rest_openapi_spec_fpath:
+  rest_openapi_dest_fpath:
     description: 'The location to output the compiled openapi spec JSON file'
     required: true
   version:
@@ -43,12 +43,12 @@ runs:
           echo "::error::required input not provided: rest_openapi_paths_dir"
           exit 1
         fi
-        if [ -z "${{ inputs.rest_openapi_prebuild_fpath }}" ]; then
-          echo "::error::required input not provided: rest_openapi_prebuild_fpath"
+        if [ -z "${{ inputs.rest_openapi_base_fpath }}" ]; then
+          echo "::error::required input not provided: rest_openapi_base_fpath"
           exit 1
         fi
-        if [ -z "${{ inputs.rest_openapi_spec_fpath }}" ]; then
-          echo "::error::required input not provided: rest_openapi_spec_fpath"
+        if [ -z "${{ inputs.rest_openapi_dest_fpath }}" ]; then
+          echo "::error::required input not provided: rest_openapi_dest_fpath"
           exit 1
         fi
         if [ -z "${{ inputs.version }}" ]; then
@@ -100,12 +100,10 @@ runs:
         # edit
         TMP_FILE="$(mktemp)"
         jq --arg version "${{ inputs.version }}" \
-            '.info.version = $version' "${{ inputs.rest_openapi_spec_fpath }}" \
+            '.info.version = $version' "${{ inputs.rest_openapi_base_fpath }}" \
             > "$TMP_FILE"
-        mv "$TMP_FILE" "${{ inputs.rest_openapi_spec_fpath }}"
-        echo "Updated version to ${{ inputs.version }} in ${{ inputs.rest_openapi_spec_fpath }}"
-        
-        cat "${{ inputs.rest_openapi_spec_fpath }}"
+        mv "$TMP_FILE" "${{ inputs.rest_openapi_base_fpath }}"
+        echo "Updated version to ${{ inputs.version }} in ${{ inputs.rest_openapi_base_fpath }}"
       shell: bash
 
     - name: modify REST path schemas - ${{ inputs.rest_openapi_paths_dir }}
@@ -126,7 +124,7 @@ runs:
             ${{ github.workspace }}/${{ inputs.db_jsonschema_dir }}
       shell: bash
 
-    - name: auto-build ${{ inputs.rest_openapi_spec_fpath }}
+    - name: auto-build ${{ inputs.rest_openapi_dest_fpath }}
       if: env.IS_GIT_BEHIND != 'true'
       run: |
         set -euo pipefail
@@ -137,8 +135,8 @@ runs:
         # (NOT THE AUTO-GENERATED FILE) AND COMMITTED.
 
         python ${{ github.action_path }}/scripts/build_openapi_schema.py \
-            --src ${{ github.workspace }}/${{ inputs.rest_openapi_prebuild_fpath }} \
-            --dst ${{ github.workspace }}/${{ inputs.rest_openapi_spec_fpath }} \
+            --src ${{ github.workspace }}/${{ inputs.rest_openapi_base_fpath }} \
+            --dst ${{ github.workspace }}/${{ inputs.rest_openapi_dest_fpath }} \
             --dunder-paths-no-vprefix ${{ inputs.dunder_paths_no_vprefix }}
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -89,7 +89,7 @@ runs:
         set -euo pipefail
         echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         
-        if [[ "${{ inputs.version }}" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+        if [[ "${{ inputs.version }}" =~ ^([0-9]+)(\.[0-9]+(\.[0-9]+)?)?$ ]]; then
           echo "valid semver"
         else
           echo "::error::Invalid semver: ${{ inputs.version }}"

--- a/action.yml
+++ b/action.yml
@@ -89,6 +89,7 @@ runs:
         set -euo pipefail
         echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         
+        # validate
         if [[ "${{ inputs.version }}" =~ ^([0-9]+)(\.[0-9]+(\.[0-9]+)?)?$ ]]; then
           echo "valid semver"
         else
@@ -96,12 +97,15 @@ runs:
           exit 2
         fi
         
+        # edit
         TMP_FILE="$(mktemp)"
         jq --arg version "${{ inputs.version }}" \
             '.info.version = $version' "${{ inputs.rest_openapi_spec_fpath }}" \
             > "$TMP_FILE"
         mv "$TMP_FILE" "${{ inputs.rest_openapi_spec_fpath }}"
         echo "Updated version to ${{ inputs.version }} in ${{ inputs.rest_openapi_spec_fpath }}"
+        
+        cat "${{ inputs.rest_openapi_spec_fpath }}"
       shell: bash
 
     - name: modify REST path schemas - ${{ inputs.rest_openapi_paths_dir }}

--- a/action.yml
+++ b/action.yml
@@ -116,6 +116,6 @@ runs:
         set -euo pipefail
         echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         git add . || true
-        git commit -m "<ci> modify openapi/jsonschema file(s)" || true
+        git commit -m "<ci> modify json schema and/or openapi file(s)" || true
         git push || true
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   rest_openapi_spec_fpath:
     description: 'The location to output the compiled openapi spec JSON file'
     required: true
+  version:
+    description: 'The version number to append to each route and update in the the openapi schema (future: automate version finding)'
+    required: true
   # OPTIONAL
   db_jsonschema_dir:
     description: 'OPTIONAL: The directory containing jsonschema-valid JSON files for objects in a database (mongodb)'
@@ -74,6 +77,20 @@ runs:
         echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
         git config user.name ${{ inputs.git_committer_name }}
         git config user.email ${{ inputs.git_committer_email }}
+      shell: bash
+
+    - name: modify REST path schemas - ${{ inputs.rest_openapi_paths_dir }}
+      if: env.IS_GIT_BEHIND != 'true' && inputs.version != ''
+      run: |
+        set -euo pipefail
+        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
+        
+        TMP_FILE="$(mktemp)"
+        jq --arg version "${{ inputs.version }}" \
+            '.info.version = $version' "${{ inputs.rest_openapi_spec_fpath }}" \
+            > "$TMP_FILE"
+        mv "$TMP_FILE" "${{ inputs.rest_openapi_spec_fpath }}"
+        echo "Updated version to ${{ inputs.version }} in ${{ inputs.rest_openapi_spec_fpath }}"
       shell: bash
 
     - name: modify REST path schemas - ${{ inputs.rest_openapi_paths_dir }}


### PR DESCRIPTION
- `version`: This required input is the version number to prepend to each route and update in the openapi schema.
- Renames previous inputs to `rest_openapi_base_fpath` and `rest_openapi_dest_fpath`.